### PR TITLE
Update to use Embassy async functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ embassy-stm32 = { version = "0.2.0", features = [
   "stm32f303vc",
   "memory-x",
   "time-driver-any",
+  "exti",
 ] }
 libm = "0.2.11"
 panic-probe = "0.3.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ pub struct LedController {
 }
 
 impl LedController {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pe8: PE8,
         pe9: PE9,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,17 +25,17 @@ pub struct Pmsa003iData {
 
     // The environmental units take into account factors like ambient pressure.
     // This is typically what is used in an AQI report or forecast.
-    pm1_0_env: u16, // PM1.0 concentration unit μ g/m3（environmental units）
-    pm2_5_env: u16, // PM2.5 concentration unit μ g/m3（environmental units）
-    pm10_env: u16,  // PM10 concentration unit μ g/m3  (environmental units)
+    _pm1_0_env: u16, // PM1.0 concentration unit μ g/m3（environmental units）
+    pm2_5_env: u16,  // PM2.5 concentration unit μ g/m3（environmental units）
+    _pm10_env: u16,  // PM10 concentration unit μ g/m3  (environmental units)
 
     // The particle count per volume of air is often used in a cleanroom context.
-    particles_0_3: u16, // Number of particles with diameter beyond 0.3 um in 0.1L of air
-    particles_0_5: u16, // Number of particles with diameter beyond 0.5 um in 0.1L of air
-    particles_1_0: u16, // Number of particles with diameter beyond 1.0 um in 0.1L of air
-    particles_2_5: u16, // Number of particles with diameter beyond 2.5 um in 0.1L of air
-    particles_5_0: u16, // Number of particles with diameter beyond 5.0 um in 0.1L of air
-    particles_10: u16,  // Number of particles with diameter beyond 10 um in 0.1L of air
+    _particles_0_3: u16, // Number of particles with diameter beyond 0.3 um in 0.1L of air
+    _particles_0_5: u16, // Number of particles with diameter beyond 0.5 um in 0.1L of air
+    _particles_1_0: u16, // Number of particles with diameter beyond 1.0 um in 0.1L of air
+    _particles_2_5: u16, // Number of particles with diameter beyond 2.5 um in 0.1L of air
+    _particles_5_0: u16, // Number of particles with diameter beyond 5.0 um in 0.1L of air
+    _particles_10: u16,  // Number of particles with diameter beyond 10 um in 0.1L of air
 }
 
 // Color enum to map AQI value to LED color
@@ -333,15 +333,15 @@ fn parse_data(buffer: &mut [u8]) -> Result<Pmsa003iData, &'static str> {
         _pm1_0_standard: u16::from_be_bytes([buffer[4], buffer[5]]),
         _pm2_5_standard: u16::from_be_bytes([buffer[6], buffer[7]]),
         _pm10_standard: u16::from_be_bytes([buffer[8], buffer[9]]),
-        pm1_0_env: u16::from_be_bytes([buffer[10], buffer[11]]),
+        _pm1_0_env: u16::from_be_bytes([buffer[10], buffer[11]]),
         pm2_5_env: u16::from_be_bytes([buffer[12], buffer[13]]),
-        pm10_env: u16::from_be_bytes([buffer[14], buffer[15]]),
-        particles_0_3: u16::from_be_bytes([buffer[16], buffer[17]]),
-        particles_0_5: u16::from_be_bytes([buffer[18], buffer[19]]),
-        particles_1_0: u16::from_be_bytes([buffer[20], buffer[21]]),
-        particles_2_5: u16::from_be_bytes([buffer[22], buffer[23]]),
-        particles_5_0: u16::from_be_bytes([buffer[24], buffer[25]]),
-        particles_10: u16::from_be_bytes([buffer[26], buffer[27]]),
+        _pm10_env: u16::from_be_bytes([buffer[14], buffer[15]]),
+        _particles_0_3: u16::from_be_bytes([buffer[16], buffer[17]]),
+        _particles_0_5: u16::from_be_bytes([buffer[18], buffer[19]]),
+        _particles_1_0: u16::from_be_bytes([buffer[20], buffer[21]]),
+        _particles_2_5: u16::from_be_bytes([buffer[22], buffer[23]]),
+        _particles_5_0: u16::from_be_bytes([buffer[24], buffer[25]]),
+        _particles_10: u16::from_be_bytes([buffer[26], buffer[27]]),
     })
 }
 


### PR DESCRIPTION
This modifies the existing code to use Embassy non-blocking code and configuration. It allows data collection to be triggered by a button push on the discovery board. It also refactors and consolidates the existing data output. Closes #5.

**Next steps** will be to refactor the nested `match` statements to be more readable.

Based on Embassy code examples:
- [Embassy docs with async button example](https://embassy.dev/book/#_async_version)
- [i2c_async example for stm32f4](https://github.com/embassy-rs/embassy/blob/9d672c44d1dccaac039c656bc2986c4fcf9823c9/examples/stm32f4/src/bin/i2c_async.rs)
- [Embassy examples for STM32F3 family](https://github.com/embassy-rs/embassy/tree/main/examples/stm32f3)

Other relevant docs:
- [Embassy I2c struct](https://docs.embassy.dev/embassy-stm32/git/stm32c011d6/i2c/struct.I2c.html)
- [Sharing peripherals between tasks](https://embassy.dev/book/#_sharing_peripherals_between_tasks) - **note**: this example was not used directly, but it may be helpful in the future if it becomes necessary to modify the `fetch_data` function added here in order to support access across multiple `embassy_executor::task`s
- The Discovery Kit PDF (found online and in the docs directory here) was referenced to confirm the correct DMA tx and rx pins needed to configure the async I2C instance