### PR TITLE
Move AQI into library and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aqi"
+version = "0.1.0"
+dependencies = [
+ "aqi",
+ "libm",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +627,7 @@ dependencies = [
 name = "quick_aqi"
 version = "0.1.0"
 dependencies = [
+ "aqi",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["libs/aqi"]
+
 [package]
 authors = ["Niklas Anderson <nkanders@gmail.com>"]
 name = "quick_aqi"
@@ -5,6 +8,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+aqi = { path = "libs/aqi" }
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.5", features = ["device"] }
 cortex-m-semihosting = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ Register 0x1F: 0x86
 Calculated AQI: 183, Color: Red
 ```
 
+## Tests
+
+A number of testing challenges arose, which are covered in more detail below. It is possible to run some basic tests for the AQI library using the following command (replace the target triple with the current host machine):
+
+```sh
+cargo test -p aqi --target aarch64-apple-darwin --lib
+```
+
+This runs the tests for only the `aqi` package, and only runs the library tests, which excludes Rustdoc examples. The target triple above works on an Apple silicon device. An alternative value for a 64-bit Linux machine would be `x86_64-unknown-linux-gnu`.
+
+
 ## Challenges and Successes
 
 As with many embedded projects, the biggest challenges were at the beginning, in basic project setup and initial I2C communication with the sensor. I attempted to start by using blocking functions in order to keep the code within my current understanding of Rust. It's clear that Embassy is built for use with `async..await` though, so the initial project setup was maybe more difficult than when using non-blocking functions, but probably more understandable.

--- a/libs/aqi/Cargo.toml
+++ b/libs/aqi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aqi"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = [] # no_std by default
+std = []     # Feature flag for std support
+
+[dependencies]
+libm = "0.2.11"
+
+[dev-dependencies]
+# Enable the std feature during tests
+aqi = { path = ".", features = ["std"] }

--- a/libs/aqi/src/lib.rs
+++ b/libs/aqi/src/lib.rs
@@ -125,17 +125,44 @@ mod tests {
 
     #[test]
     fn test_calculate_aqi() {
-        //
-        // Test validation success
-        //
-        let mut data = [0u8; 32];
-        // Fill first 30 bytes with 1s
-        data[..30].copy_from_slice(&[1; 30]);
-        // Calculate correct checksum
-        let checksum: u16 = data[..30].iter().map(|&b| b as u16).sum();
-        // Store it in big-endian format
-        data[30..32].copy_from_slice(&checksum.to_be_bytes());
+        // These expected values were confirmed using
+        // https://www.airnow.gov/aqi/aqi-calculator-concentration/
+        assert_eq!(calculate_aqi(0.0), 0);
+        assert_eq!(calculate_aqi(4.5), 25);
+        assert_eq!(calculate_aqi(9.0), 50);
+        assert_eq!(calculate_aqi(35.5), 101);
+        assert_eq!(calculate_aqi(45.0), 124);
+        assert_eq!(calculate_aqi(55.4), 150);
+        assert_eq!(calculate_aqi(55.5), 151);
+        assert_eq!(calculate_aqi(90.0), 175);
+        assert_eq!(calculate_aqi(125.4), 200);
+        assert_eq!(calculate_aqi(125.5), 201);
+        assert_eq!(calculate_aqi(175.0), 250);
+        assert_eq!(calculate_aqi(225.4), 300);
+        assert_eq!(calculate_aqi(225.5), 301);
+        assert_eq!(calculate_aqi(500.0), 500);
+    }
 
-        assert_eq!(validate_checksum(&data), Ok(()));
+    #[test]
+    fn test_get_aqi_color() {
+        assert_eq!(get_aqi_color(0), Color::Green);
+        assert_eq!(get_aqi_color(25), Color::Green);
+        assert_eq!(get_aqi_color(50), Color::Green);
+        assert_eq!(get_aqi_color(51), Color::Yellow);
+        assert_eq!(get_aqi_color(75), Color::Yellow);
+        assert_eq!(get_aqi_color(100), Color::Yellow);
+        assert_eq!(get_aqi_color(101), Color::Orange);
+        assert_eq!(get_aqi_color(125), Color::Orange);
+        assert_eq!(get_aqi_color(150), Color::Orange);
+        assert_eq!(get_aqi_color(151), Color::Red);
+        assert_eq!(get_aqi_color(175), Color::Red);
+        assert_eq!(get_aqi_color(200), Color::Red);
+        assert_eq!(get_aqi_color(201), Color::Purple);
+        assert_eq!(get_aqi_color(250), Color::Purple);
+        assert_eq!(get_aqi_color(300), Color::Purple);
+        assert_eq!(get_aqi_color(301), Color::DarkPurple);
+        assert_eq!(get_aqi_color(400), Color::DarkPurple);
+        assert_eq!(get_aqi_color(500), Color::DarkPurple);
+        assert_eq!(get_aqi_color(999), Color::DarkPurple);
     }
 }

--- a/libs/aqi/src/lib.rs
+++ b/libs/aqi/src/lib.rs
@@ -3,6 +3,11 @@
 //! This module provides supporting functionality for AQI calculations and
 //! translations to EPA specified AQI color ranges.
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 /// Color enum provides colors corresponding to EPA AQI levels
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Color {
@@ -111,5 +116,26 @@ pub fn get_aqi_color(aqi: u16) -> Color {
         151..=200 => Color::Red,
         201..=300 => Color::Purple,
         _ => Color::DarkPurple,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_aqi() {
+        //
+        // Test validation success
+        //
+        let mut data = [0u8; 32];
+        // Fill first 30 bytes with 1s
+        data[..30].copy_from_slice(&[1; 30]);
+        // Calculate correct checksum
+        let checksum: u16 = data[..30].iter().map(|&b| b as u16).sum();
+        // Store it in big-endian format
+        data[30..32].copy_from_slice(&checksum.to_be_bytes());
+
+        assert_eq!(validate_checksum(&data), Ok(()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,10 @@
 #![no_std]
 #![no_main]
 
-mod aqi;
 mod pmsa003i;
 
-use crate::aqi::Color;
 use crate::pmsa003i::Pmsa003iData;
+use aqi::*;
 use cortex_m_semihosting::hprintln;
 use embassy_executor::Spawner;
 use embassy_stm32::bind_interrupts;


### PR DESCRIPTION
Moves the AQI functionality into a separate library to facilitate testing on a host machine instead of a `no_std` environment. These simple functions are well-suited to be used across environments anyways.

Crediting chatGPT here with assistance on configuring a separate library with support for `std` and `no_std` capabilities.